### PR TITLE
Fix compressed data file name

### DIFF
--- a/dicomexporter/exporter.py
+++ b/dicomexporter/exporter.py
@@ -216,4 +216,4 @@ def compressWithGzip(file_path):
         shutil.copyfileobj(f_in, f_out)
         f_in.close()
         f_out.close()
-    os.replace(file_path + '.gz', file_path)
+    os.remove(file_path)


### PR DESCRIPTION
A compressed data file must have a .gz extension.
Hence it can be correctly found when fetchGzip is true.