### PR TITLE
FIX: Call correct filename method when using vtkJSONDataSetWriter

### DIFF
--- a/dicomexporter/exporter.py
+++ b/dicomexporter/exporter.py
@@ -166,10 +166,10 @@ def convertDICOMVolumeToVTKFile(
         if compress:
             writer.SetCompressorTypeToZLib()
             writer.SetBlockSize(blockSize)
+        writer.SetFileName(output_file_path)
     else: # vtkjs
         writer = vtk.vtkJSONDataSetWriter()
-
-    writer.SetFileName(output_file_path)
+        writer.GetArchiver().SetArchiveName(output_file_path)
 
     # Set writer volume data #
     writer.SetInputData(volumeData)


### PR DESCRIPTION
`SetFileName` method from vtkJSONDataSetWriter is deprecated since vtk 9.0.
Use the correct setter for the file name according to the vtk version.