### PR TITLE
Add --resample flag and use direction matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ dicom-exporter <path/to/dicom/folder> <path/to/output.vtkjs>
 Setting the `--convert-12-bits`-flag will convert the resulting VTK file using 12 bits instead of 16 bits per block. This is only applied if the input DICOM files are encoded in 12 bits instead of 16 bits (i.e. BitsStored is 12 in the DICOM metadata).
 
 The output file is compressed using gzip for VTK.JS files and ZLib for VTI files, unless the `--no-compress` flag is set.
+
+Use `--resample` flag to resample the volume using the closest axis aligned direction matrix. This resampling will set the direction matrix to identity (legacy behavior).

--- a/dicomexporter/cli.py
+++ b/dicomexporter/cli.py
@@ -10,6 +10,7 @@ def main():
     parser.add_argument("--no-compress", action="store_true", help="Do not compress output with ZLib (VTI) or gzip (VTK.JS)")
     parser.add_argument("--convert-12-bits", action="store_true", help="Converts from 16 to 12 bits")
     parser.add_argument("--overwrite", action="store_true", help="Overwrite output")
+    parser.add_argument("--resample", action="store_true", help="Resample using the closest axis aligned orientation, discard volume orientation")
 
     args = parser.parse_args()
 
@@ -19,4 +20,5 @@ def main():
         overwrite=args.overwrite,
         compress=not args.no_compress,
         convert_12_bits=args.convert_12_bits,
+        resample=args.resample,
     )


### PR DESCRIPTION
Breaking change:
To reproduce the old behavior, use the `--resample` flag.

The exporter will support direction matrix on `.vtkjs` exports as soon as you use a VTK wrapping with [this MR](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10593) merged.
